### PR TITLE
Use Next.js Link on home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
+import Link from 'next/link'
+
 export default function HomePage() {
 return (
 <section className="container">
 <div className="card p-8 text-center">
 <h1 className="text-3xl font-semibold">ConsultaDoc</h1>
 <p className="mt-2">Agenda y gestiona consultas médicas de forma segura.</p>
-<a href="/login" className="btn mt-6">Ingresar</a>
+<Link href="/login" className="btn mt-6">Ingresar</Link>
 </div>
 </section>
 )


### PR DESCRIPTION
## Summary
- replace home page anchor tag with Next.js Link

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*
- `npm run typecheck` *(fails: Cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6f6e1cc08329aea3ae5e0b8da239