### PR TITLE
feat: memoize supabase client

### DIFF
--- a/src/app/(dashboard)/dashboard/citas/nueva/page.tsx
+++ b/src/app/(dashboard)/dashboard/citas/nueva/page.tsx
@@ -1,47 +1,73 @@
-'use client'
-import { useState } from 'react'
-import { supabaseBrowser } from '@/lib/supabase/browser'
-import { useRouter } from 'next/navigation'
-
+"use client";
+import { useState } from "react";
+import { supabaseBrowser } from "@/lib/supabase/browser";
+import { useRouter } from "next/navigation";
 
 export default function NuevaCitaPage() {
-const supabase = supabaseBrowser()
-const router = useRouter()
-const [fecha, setFecha] = useState('')
-const [motivo, setMotivo] = useState('')
-const [clinicaId, setClinicaId] = useState('')
-const [pacienteId, setPacienteId] = useState('')
-const [medicoId, setMedicoId] = useState('')
-const [error, setError] = useState<string | null>(null)
+  const supabase = supabaseBrowser;
+  const router = useRouter();
+  const [fecha, setFecha] = useState("");
+  const [motivo, setMotivo] = useState("");
+  const [clinicaId, setClinicaId] = useState("");
+  const [pacienteId, setPacienteId] = useState("");
+  const [medicoId, setMedicoId] = useState("");
+  const [error, setError] = useState<string | null>(null);
 
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const { error } = await supabase.from("citas").insert({
+      clinica_id: clinicaId,
+      paciente_id: pacienteId,
+      medico_id: medicoId,
+      fecha: new Date(fecha).toISOString(),
+      motivo,
+    });
+    if (error) return setError(error.message);
+    router.push("/dashboard/citas");
+  };
 
-const onSubmit = async (e: React.FormEvent) => {
-e.preventDefault()
-setError(null)
-const { error } = await supabase.from('citas').insert({
-clinica_id: clinicaId,
-paciente_id: pacienteId,
-medico_id: medicoId,
-fecha: new Date(fecha).toISOString(),
-motivo
-})
-if (error) return setError(error.message)
-router.push('/dashboard/citas')
-}
-
-
-return (
-<div className="max-w-lg card p-6 mx-auto">
-<h2 className="text-xl font-semibold">Nueva cita</h2>
-<form className="mt-4 space-y-3" onSubmit={onSubmit}>
-<input className="input" placeholder="Clínica ID" value={clinicaId} onChange={e=>setClinicaId(e.target.value)} required />
-<input className="input" placeholder="Paciente (UUID)" value={pacienteId} onChange={e=>setPacienteId(e.target.value)} required />
-<input className="input" placeholder="Médico (UUID)" value={medicoId} onChange={e=>setMedicoId(e.target.value)} required />
-<input className="input" type="datetime-local" value={fecha} onChange={e=>setFecha(e.target.value)} required />
-<input className="input" placeholder="Motivo" value={motivo} onChange={e=>setMotivo(e.target.value)} />
-{error && <p className="text-red-600 text-sm">{error}</p>}
-<button className="btn w-full">Crear</button>
-</form>
-</div>
-)
+  return (
+    <div className="max-w-lg card p-6 mx-auto">
+      <h2 className="text-xl font-semibold">Nueva cita</h2>
+      <form className="mt-4 space-y-3" onSubmit={onSubmit}>
+        <input
+          className="input"
+          placeholder="Clínica ID"
+          value={clinicaId}
+          onChange={(e) => setClinicaId(e.target.value)}
+          required
+        />
+        <input
+          className="input"
+          placeholder="Paciente (UUID)"
+          value={pacienteId}
+          onChange={(e) => setPacienteId(e.target.value)}
+          required
+        />
+        <input
+          className="input"
+          placeholder="Médico (UUID)"
+          value={medicoId}
+          onChange={(e) => setMedicoId(e.target.value)}
+          required
+        />
+        <input
+          className="input"
+          type="datetime-local"
+          value={fecha}
+          onChange={(e) => setFecha(e.target.value)}
+          required
+        />
+        <input
+          className="input"
+          placeholder="Motivo"
+          value={motivo}
+          onChange={(e) => setMotivo(e.target.value)}
+        />
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <button className="btn w-full">Crear</button>
+      </form>
+    </div>
+  );
 }

--- a/src/app/(dashboard)/dashboard/citas/page.tsx
+++ b/src/app/(dashboard)/dashboard/citas/page.tsx
@@ -1,55 +1,55 @@
-'use client'
-import { useEffect, useState } from 'react'
-import { supabaseBrowser } from '@/lib/supabase/browser'
+"use client";
+import { useEffect, useState } from "react";
+import { supabaseBrowser } from "@/lib/supabase/browser";
 
-
-type Cita = { id: string; fecha: string; estado: string; motivo: string }
-
+type Cita = { id: string; fecha: string; estado: string; motivo: string };
 
 export default function CitasPage() {
-const supabase = supabaseBrowser()
-const [citas, setCitas] = useState<Cita[]>([])
+  const supabase = supabaseBrowser;
+  const [citas, setCitas] = useState<Cita[]>([]);
 
+  useEffect(() => {
+    const load = async () => {
+      const { data } = await supabase
+        .from("citas")
+        .select("id, fecha, estado, motivo")
+        .order("fecha", { ascending: true })
+        .limit(50);
+      setCitas(data || []);
+    };
+    load();
+  }, []);
 
-useEffect(() => {
-const load = async () => {
-const { data } = await supabase
-.from('citas')
-.select('id, fecha, estado, motivo')
-.order('fecha', { ascending: true })
-.limit(50)
-setCitas(data || [])
-}
-load()
-}, [])
-
-
-return (
-<div className="card p-6">
-<div className="flex items-center justify-between flex-wrap gap-2">
-<h2 className="text-xl font-semibold">Citas</h2>
-<a href="/dashboard/citas/nueva" className="btn">Nueva cita</a>
-</div>
-<div className="mt-4 overflow-x-auto">
-<table className="min-w-full text-sm">
-<thead>
-<tr className="text-left">
-<th className="py-2 pr-4">Fecha</th>
-<th className="py-2 pr-4">Estado</th>
-<th className="py-2 pr-4">Motivo</th>
-</tr>
-</thead>
-<tbody>
-{citas.map(c => (
-<tr key={c.id} className="border-t">
-<td className="py-2 pr-4">{new Date(c.fecha).toLocaleString()}</td>
-<td className="py-2 pr-4 capitalize">{c.estado}</td>
-<td className="py-2 pr-4">{c.motivo ?? '—'}</td>
-</tr>
-))}
-</tbody>
-</table>
-</div>
-</div>
-)
+  return (
+    <div className="card p-6">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <h2 className="text-xl font-semibold">Citas</h2>
+        <a href="/dashboard/citas/nueva" className="btn">
+          Nueva cita
+        </a>
+      </div>
+      <div className="mt-4 overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="py-2 pr-4">Fecha</th>
+              <th className="py-2 pr-4">Estado</th>
+              <th className="py-2 pr-4">Motivo</th>
+            </tr>
+          </thead>
+          <tbody>
+            {citas.map((c) => (
+              <tr key={c.id} className="border-t">
+                <td className="py-2 pr-4">
+                  {new Date(c.fecha).toLocaleString()}
+                </td>
+                <td className="py-2 pr-4 capitalize">{c.estado}</td>
+                <td className="py-2 pr-4">{c.motivo ?? "—"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
 }

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,13 +1,19 @@
-import { supabaseBrowser } from '@/lib/supabase/browser'
-
-
 export default async function DashboardPage() {
-// Placeholder serverless fetch; en producción usar Server Components con cookies
-return (
-<section className="grid gap-4 md:grid-cols-3">
-<div className="card p-6"><h3 className="font-semibold">Citas de hoy</h3><p className="text-sm">Próximamente…</p></div>
-<div className="card p-6"><h3 className="font-semibold">Pacientes</h3><p className="text-sm">Próximamente…</p></div>
-<div className="card p-6"><h3 className="font-semibold">Mi disponibilidad</h3><p className="text-sm">Próximamente…</p></div>
-</section>
-)
+  // Placeholder serverless fetch; en producción usar Server Components con cookies
+  return (
+    <section className="grid gap-4 md:grid-cols-3">
+      <div className="card p-6">
+        <h3 className="font-semibold">Citas de hoy</h3>
+        <p className="text-sm">Próximamente…</p>
+      </div>
+      <div className="card p-6">
+        <h3 className="font-semibold">Pacientes</h3>
+        <p className="text-sm">Próximamente…</p>
+      </div>
+      <div className="card p-6">
+        <h3 className="font-semibold">Mi disponibilidad</h3>
+        <p className="text-sm">Próximamente…</p>
+      </div>
+    </section>
+  );
 }

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,37 +1,54 @@
-'use client'
-import { useState } from 'react'
-import { supabaseBrowser } from '@/lib/supabase/browser'
-import { useRouter } from 'next/navigation'
-
+"use client";
+import { useState } from "react";
+import { supabaseBrowser } from "@/lib/supabase/browser";
+import { useRouter } from "next/navigation";
 
 export default function LoginPage() {
-const supabase = supabaseBrowser()
-const router = useRouter()
-const [email, setEmail] = useState('')
-const [password, setPassword] = useState('')
-const [loading, setLoading] = useState(false)
-const [error, setError] = useState<string | null>(null)
+  const supabase = supabaseBrowser;
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    const { data, error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    setLoading(false);
+    if (error) return setError(error.message);
+    if (data.session) router.push("/dashboard");
+  };
 
-const onSubmit = async (e: React.FormEvent) => {
-e.preventDefault()
-setError(null); setLoading(true)
-const { data, error } = await supabase.auth.signInWithPassword({ email, password })
-setLoading(false)
-if (error) return setError(error.message)
-if (data.session) router.push('/dashboard')
-}
-
-
-return (
-<div className="max-w-md mx-auto card p-6">
-<h2 className="text-2xl font-semibold">Iniciar sesión</h2>
-<form className="mt-4 space-y-3" onSubmit={onSubmit}>
-<input className="input" placeholder="Email" type="email" value={email} onChange={e=>setEmail(e.target.value)} required />
-<input className="input" placeholder="Contraseña" type="password" value={password} onChange={e=>setPassword(e.target.value)} required />
-{error && <p className="text-red-600 text-sm">{error}</p>}
-<button className="btn w-full" disabled={loading}>{loading ? 'Ingresando…' : 'Entrar'}</button>
-</form>
-</div>
-)
+  return (
+    <div className="max-w-md mx-auto card p-6">
+      <h2 className="text-2xl font-semibold">Iniciar sesión</h2>
+      <form className="mt-4 space-y-3" onSubmit={onSubmit}>
+        <input
+          className="input"
+          placeholder="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          className="input"
+          placeholder="Contraseña"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <button className="btn w-full" disabled={loading}>
+          {loading ? "Ingresando…" : "Entrar"}
+        </button>
+      </form>
+    </div>
+  );
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,36 +1,45 @@
-'use client'
-import Link from 'next/link'
-import { useEffect, useState } from 'react'
-import { supabaseBrowser } from '@/lib/supabase/browser'
+"use client";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { supabaseBrowser } from "@/lib/supabase/browser";
 
+export default function Navbar() {
+  const supabase = supabaseBrowser;
+  const [logged, setLogged] = useState(false);
 
-export default function Navbar(){
-const supabase = supabaseBrowser()
-const [logged, setLogged] = useState(false)
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => setLogged(!!data.session));
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, s) =>
+      setLogged(!!s),
+    );
+    return () => {
+      sub.subscription.unsubscribe();
+    };
+  }, []);
 
-
-useEffect(() => {
-supabase.auth.getSession().then(({ data }) => setLogged(!!data.session))
-const { data: sub } = supabase.auth.onAuthStateChange((_e, s) => setLogged(!!s))
-return () => { sub.subscription.unsubscribe() }
-}, [])
-
-
-return (
-<nav className="border-b bg-white">
-<div className="container h-14 flex items-center justify-between">
-<Link href="/" className="font-semibold">ConsultaDoc</Link>
-<div className="flex items-center gap-3">
-{logged ? (
-<>
-<Link className="btn" href="/dashboard">Dashboard</Link>
-<button className="btn" onClick={() => supabase.auth.signOut()}>Salir</button>
-</>
-) : (
-<Link className="btn" href="/login">Ingresar</Link>
-)}
-</div>
-</div>
-</nav>
-)
+  return (
+    <nav className="border-b bg-white">
+      <div className="container h-14 flex items-center justify-between">
+        <Link href="/" className="font-semibold">
+          ConsultaDoc
+        </Link>
+        <div className="flex items-center gap-3">
+          {logged ? (
+            <>
+              <Link className="btn" href="/dashboard">
+                Dashboard
+              </Link>
+              <button className="btn" onClick={() => supabase.auth.signOut()}>
+                Salir
+              </button>
+            </>
+          ) : (
+            <Link className="btn" href="/login">
+              Ingresar
+            </Link>
+          )}
+        </div>
+      </div>
+    </nav>
+  );
 }

--- a/src/lib/supabase/browser.ts
+++ b/src/lib/supabase/browser.ts
@@ -1,10 +1,24 @@
-'use client'
-import { createClient } from '@supabase/supabase-js'
+"use client";
 
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-export const supabaseBrowser = () =>
-createClient(
-process.env.NEXT_PUBLIC_SUPABASE_URL!,
-process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-{ auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true } }
-)
+const globalForSupabase = globalThis as unknown as {
+  supabaseBrowser: SupabaseClient | undefined;
+};
+
+export const supabaseBrowser =
+  globalForSupabase.supabaseBrowser ??
+  createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      auth: {
+        persistSession: true,
+        autoRefreshToken: true,
+        detectSessionInUrl: true,
+      },
+    },
+  );
+
+if (process.env.NODE_ENV !== "production")
+  globalForSupabase.supabaseBrowser = supabaseBrowser;

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,9 +1,16 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
+const globalForSupabase = globalThis as unknown as {
+  supabaseServer: SupabaseClient | undefined;
+};
 
-export const supabaseServer = () =>
-createClient(
-process.env.NEXT_PUBLIC_SUPABASE_URL!,
-process.env.SUPABASE_SERVICE_ROLE_KEY!,
-{ auth: { persistSession: false, autoRefreshToken: false } }
-)
+export const supabaseServer =
+  globalForSupabase.supabaseServer ??
+  createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false, autoRefreshToken: false } },
+  );
+
+if (process.env.NODE_ENV !== "production")
+  globalForSupabase.supabaseServer = supabaseServer;


### PR DESCRIPTION
## Summary
- memoize Supabase browser and server clients to reuse a single instance
- update components to consume the shared client instance

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt: How would you like to configure ESLint?)*
- `npm run typecheck` *(fails: Cannot find module '@/lib/supabase/browser')*


------
https://chatgpt.com/codex/tasks/task_e_68bb78cb39f883298b65bb2134aefee7