### PR TITLE
refactor: add proper props typing to UI components

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,4 +1,14 @@
+import React, { ComponentProps, ElementType } from 'react'
 import { cn } from './utils'
-export default function Button({ as:As='button', className, ...props }: any){
-return <As className={cn('btn', className)} {...props} />
+
+type ButtonProps = ComponentProps<'button'> & {
+  as?: ElementType
+}
+
+export default function Button({
+  as: As = 'button',
+  className,
+  ...props
+}: ButtonProps) {
+  return <As className={cn('btn', className)} {...props} />
 }

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,4 +1,8 @@
+import React, { InputHTMLAttributes } from 'react'
 import { cn } from './utils'
-export default function Input({ className, ...props }: any){
-return <input className={cn('input', className)} {...props} />
+
+type InputProps = InputHTMLAttributes<HTMLInputElement>
+
+export default function Input({ className, ...props }: InputProps) {
+  return <input className={cn('input', className)} {...props} />
 }

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,3 +1,11 @@
-export default function Select({ children, ...props }: any){
-return <select className="input" {...props}>{children}</select>
+import React, { SelectHTMLAttributes } from 'react'
+
+type SelectProps = SelectHTMLAttributes<HTMLSelectElement>
+
+export default function Select({ children, ...props }: SelectProps) {
+  return (
+    <select className="input" {...props}>
+      {children}
+    </select>
+  )
 }


### PR DESCRIPTION
## Summary
- type Button using `ComponentProps<'button'>` and optional `as` element
- replace `any` with `InputHTMLAttributes` for Input
- replace `any` with `SelectHTMLAttributes` for Select

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bb83a9724083299c84ec80ca1bfaf1