### PR TITLE
chore: format codebase with Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 # ConsultaDoc
+
 SaaS para gestión de consultas médicas. Stack: Next.js + Supabase.
 
-
 ## Setup rápido
+
 1. Copia `.env.local` desde `.env.local.example`.
 2. `npm i`
 3. `npm run dev`
 4. Configura Supabase y ejecuta `supabase db push` con las migraciones.
 
-
 ## Scripts
+
 - `dev`: entorno local
 - `build` / `start`: producción
 
-
 ## Seguridad
+
 - RLS activo en todas las tablas.
 - Usa Service Role solo en Server Actions seguras.

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,17 +1,17 @@
-import { NextResponse } from 'next/server'
-import type { NextRequest } from 'next/server'
-
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
 
 export function middleware(req: NextRequest) {
-const url = req.nextUrl
-const isDashboard = url.pathname.startsWith('/dashboard')
-const hasSession = req.cookies.get('sb-access-token') || req.cookies.get('supabase-auth-token')
-if (isDashboard && !hasSession) {
-url.pathname = '/login'
-return NextResponse.redirect(url)
-}
-return NextResponse.next()
+  const url = req.nextUrl;
+  const isDashboard = url.pathname.startsWith("/dashboard");
+  const hasSession =
+    req.cookies.get("sb-access-token") ||
+    req.cookies.get("supabase-auth-token");
+  if (isDashboard && !hasSession) {
+    url.pathname = "/login";
+    return NextResponse.redirect(url);
+  }
+  return NextResponse.next();
 }
 
-
-export const config = { matcher: ['/dashboard/:path*'] }
+export const config = { matcher: ["/dashboard/:path*"] };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-reactStrictMode: true,
-experimental: { serverActions: { bodySizeLimit: '2mb' } }
+  reactStrictMode: true,
+  experimental: { serverActions: { bodySizeLimit: "2mb" } },
 };
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,30 +1,30 @@
 {
-"name": "consultadoc",
-"version": "0.1.0",
-"private": true,
-"scripts": {
-"dev": "next dev",
-"build": "next build",
-"start": "next start",
-"lint": "next lint",
-"typecheck": "tsc --noEmit",
-"format": "prettier --write ."
-},
-"dependencies": {
-"@supabase/supabase-js": "^2.45.4",
-"next": "^14.2.5",
-"react": "^18.3.1",
-"react-dom": "^18.3.1",
-"zustand": "^4.5.5"
-},
-"devDependencies": {
-"@types/node": "^20.11.30",
-"@types/react": "^18.2.66",
-"@types/react-dom": "^18.2.22",
-"autoprefixer": "^10.4.17",
-"postcss": "^8.4.35",
-"prettier": "^3.2.5",
-"tailwindcss": "^3.4.3",
-"typescript": "^5.4.5"
-}
+  "name": "consultadoc",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write ."
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.45.4",
+    "next": "^14.2.5",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "zustand": "^4.5.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.35",
+    "prettier": "^3.2.5",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.5"
+  }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
-plugins: {
-tailwindcss: {},
-autoprefixer: {}
-}
-}
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/(dashboard)/dashboard/layout.tsx
+++ b/src/app/(dashboard)/dashboard/layout.tsx
@@ -1,3 +1,7 @@
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
-return <div className="grid gap-6">{children}</div>
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <div className="grid gap-6">{children}</div>;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,19 +1,24 @@
-import '../styles/globals.css'
-import Navbar from '@/components/Navbar'
-import Footer from '@/components/Footer'
+import "../styles/globals.css";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
 
+export const metadata = {
+  title: "ConsultaDoc",
+  description: "SaaS de consultas médicas",
+};
 
-export const metadata = { title: 'ConsultaDoc', description: 'SaaS de consultas médicas' }
-
-
-export default function RootLayout({ children }: { children: React.ReactNode }) {
-return (
-<html lang="es">
-<body>
-<Navbar />
-<main className="container py-6 min-h-[70vh]">{children}</main>
-<Footer />
-</body>
-</html>
-)
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="es">
+      <body>
+        <Navbar />
+        <main className="container py-6 min-h-[70vh]">{children}</main>
+        <Footer />
+      </body>
+    </html>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,17 @@
-import Link from 'next/link'
+import Link from "next/link";
 
 export default function HomePage() {
-return (
-<section className="container">
-<div className="card p-8 text-center">
-<h1 className="text-3xl font-semibold">ConsultaDoc</h1>
-<p className="mt-2">Agenda y gestiona consultas médicas de forma segura.</p>
-<Link href="/login" className="btn mt-6">Ingresar</Link>
-</div>
-</section>
-)
+  return (
+    <section className="container">
+      <div className="card p-8 text-center">
+        <h1 className="text-3xl font-semibold">ConsultaDoc</h1>
+        <p className="mt-2">
+          Agenda y gestiona consultas médicas de forma segura.
+        </p>
+        <Link href="/login" className="btn mt-6">
+          Ingresar
+        </Link>
+      </div>
+    </section>
+  );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,10 +1,18 @@
-export default function Footer(){
-return (
-<footer className="mt-10 border-t">
-<div className="container py-6 text-sm flex items-center justify-between flex-wrap gap-2">
-<span>© {new Date().getFullYear()} Kansodata SpA. Todos los derechos reservados.</span>
-<a href="https://github.com/Kansodata/ConsultaDoc" className="underline">Repositorio</a>
-</div>
-</footer>
-)
+export default function Footer() {
+  return (
+    <footer className="mt-10 border-t">
+      <div className="container py-6 text-sm flex items-center justify-between flex-wrap gap-2">
+        <span>
+          © {new Date().getFullYear()} Kansodata SpA. Todos los derechos
+          reservados.
+        </span>
+        <a
+          href="https://github.com/Kansodata/ConsultaDoc"
+          className="underline"
+        >
+          Repositorio
+        </a>
+      </div>
+    </footer>
+  );
 }

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,14 +1,14 @@
-import React, { ComponentProps, ElementType } from 'react'
-import { cn } from './utils'
+import React, { ComponentProps, ElementType } from "react";
+import { cn } from "./utils";
 
-type ButtonProps = ComponentProps<'button'> & {
-  as?: ElementType
-}
+type ButtonProps = ComponentProps<"button"> & {
+  as?: ElementType;
+};
 
 export default function Button({
-  as: As = 'button',
+  as: As = "button",
   className,
   ...props
 }: ButtonProps) {
-  return <As className={cn('btn', className)} {...props} />
+  return <As className={cn("btn", className)} {...props} />;
 }

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,8 +1,8 @@
-import React, { InputHTMLAttributes } from 'react'
-import { cn } from './utils'
+import React, { InputHTMLAttributes } from "react";
+import { cn } from "./utils";
 
-type InputProps = InputHTMLAttributes<HTMLInputElement>
+type InputProps = InputHTMLAttributes<HTMLInputElement>;
 
 export default function Input({ className, ...props }: InputProps) {
-  return <input className={cn('input', className)} {...props} />
+  return <input className={cn("input", className)} {...props} />;
 }

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,11 +1,11 @@
-import React, { SelectHTMLAttributes } from 'react'
+import React, { SelectHTMLAttributes } from "react";
 
-type SelectProps = SelectHTMLAttributes<HTMLSelectElement>
+type SelectProps = SelectHTMLAttributes<HTMLSelectElement>;
 
 export default function Select({ children, ...props }: SelectProps) {
   return (
     <select className="input" {...props}>
       {children}
     </select>
-  )
+  );
 }

--- a/src/components/ui/utils.ts
+++ b/src/components/ui/utils.ts
@@ -1,3 +1,3 @@
-export function cn(...classes: (string|undefined|false|null)[]){
-return classes.filter(Boolean).join(' ')
+export function cn(...classes: (string | undefined | false | null)[]) {
+  return classes.filter(Boolean).join(" ");
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,10 +2,23 @@
 @tailwind components;
 @tailwind utilities;
 
-
-html, body, :root { height: 100%; }
-body { @apply bg-slate-50 text-slate-800; }
-.container { @apply mx-auto px-4; }
-.card { @apply bg-white rounded-2xl shadow-sm border border-slate-200; }
-.btn { @apply inline-flex items-center justify-center gap-2 rounded-2xl px-4 py-2 text-sm font-medium border border-slate-300 hover:border-slate-400 transition; }
-.input { @apply w-full rounded-xl border border-slate-300 px-3 py-2 outline-none focus:ring-2 focus:ring-slate-300; }
+html,
+body,
+:root {
+  height: 100%;
+}
+body {
+  @apply bg-slate-50 text-slate-800;
+}
+.container {
+  @apply mx-auto px-4;
+}
+.card {
+  @apply bg-white rounded-2xl shadow-sm border border-slate-200;
+}
+.btn {
+  @apply inline-flex items-center justify-center gap-2 rounded-2xl px-4 py-2 text-sm font-medium border border-slate-300 hover:border-slate-400 transition;
+}
+.input {
+  @apply w-full rounded-xl border border-slate-300 px-3 py-2 outline-none focus:ring-2 focus:ring-slate-300;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,9 +1,9 @@
-import type { Config } from 'tailwindcss'
+import type { Config } from "tailwindcss";
 
 export default {
-  content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
+  content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
     extend: {},
   },
   plugins: [],
-} satisfies Config
+} satisfies Config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -26,13 +22,6 @@
       }
     ]
   },
-  "include": [
-    "next-env.d.ts",
-    ".next/types/**/*.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- run `npm run format` to apply Prettier formatting across the codebase
- fix indentation and semicolons in `layout.tsx` and `middleware.ts`

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (prompts for configuration)


------
https://chatgpt.com/codex/tasks/task_e_68bb8d055f708329b5614f9926163fb6