### PR TITLE
Refactor login inputs to use Input component

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { supabaseBrowser } from "@/lib/supabase/browser";
 import { useRouter } from "next/navigation";
+import Input from "@/components/ui/Input";
 
 export default function LoginPage() {
   const supabase = supabaseBrowser;
@@ -28,16 +29,14 @@ export default function LoginPage() {
     <div className="max-w-md mx-auto card p-6">
       <h2 className="text-2xl font-semibold">Iniciar sesión</h2>
       <form className="mt-4 space-y-3" onSubmit={onSubmit}>
-        <input
-          className="input"
+        <Input
           placeholder="Email"
           type="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           required
         />
-        <input
-          className="input"
+        <Input
           placeholder="Contraseña"
           type="password"
           value={password}


### PR DESCRIPTION
## Summary
- replace plain input tags in login page with shared `Input` component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bb8eb7ae088329b71b0fe6a5fc29fd