### PR TITLE
docs: add testing guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ SaaS para gestión de consultas médicas. Stack: Next.js + Supabase.
 - `dev`: entorno local
 - `build` / `start`: producción
 
+## Testing
+
+Actualmente no hay pruebas automatizadas.
+
+Para añadirlas en el futuro:
+
+1. Instala dependencias de testing: `npm install --save-dev jest @testing-library/react @testing-library/jest-dom`.
+2. Agrega el script `"test": "jest"` en `package.json`.
+3. Crea archivos de prueba en `__tests__/` o junto a los componentes.
+
 ## Seguridad
 
 - RLS activo en todas las tablas.


### PR DESCRIPTION
## Summary
- document lack of automated tests
- add future testing setup instructions

## Testing
- `npm run lint` *(fails: Invalid package.json JSON parse error)*

------
https://chatgpt.com/codex/tasks/task_e_68bc60d8e7488329b6c9c753315ef863